### PR TITLE
Rng refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Compiled in x86-64 mode (SSE2 only)
 
 384x216 image, 100 rays per pixel
 
+The Nim sources for this benchmark can be retrived from the first release:
+
+    https://github.com/mratsim/trace-of-radiance/tree/v0.1.0
+
 ### Smallpt
 
 [SmallPT](https://www.kevinbeason.com/smallpt/) is an even smaller raytracing project

--- a/trace_of_radiance.nim
+++ b/trace_of_radiance.nim
@@ -13,7 +13,8 @@ import
     primitives,
     physics/cameras,
     render,
-    scenes
+    scenes,
+    sampling
   ]
 
 proc main() =
@@ -25,7 +26,9 @@ proc main() =
 
   stdout.write &"P3\n{image_width} {image_height}\n255\n"
 
-  let world = random_scene()
+  var worldRNG: Rng
+  worldRNG.seed 0xFACADE
+  let world = worldRNG.random_scene()
 
   let
     lookFrom = point3(13,2,3)

--- a/trace_of_radiance/physics/cameras.nim
+++ b/trace_of_radiance/physics/cameras.nim
@@ -40,8 +40,8 @@ func camera*(lookFrom, lookAt: Point3, view_up: Vec3,
                              result.vertical/2 - focus_distance*result.w
   result.lens_radius = aperture/2
 
-proc ray*(self: Camera, s, t: float64): Ray =
-  let rd = self.lens_radius * random_in_unit_disk()
+proc ray*(self: Camera, s, t: float64, rng: var Rng): Ray =
+  let rd = self.lens_radius * rng.random_in_unit_disk(Vec3)
   let offset = self.u*rd.x + self.v*rd.y
   ray(
     origin = self.origin + offset,

--- a/trace_of_radiance/physics/cameras.nim
+++ b/trace_of_radiance/physics/cameras.nim
@@ -40,7 +40,7 @@ func camera*(lookFrom, lookAt: Point3, view_up: Vec3,
                              result.vertical/2 - focus_distance*result.w
   result.lens_radius = aperture/2
 
-proc ray*(self: Camera, s, t: float64, rng: var Rng): Ray =
+func ray*(self: Camera, s, t: float64, rng: var Rng): Ray =
   let rd = self.lens_radius * rng.random_in_unit_disk(Vec3)
   let offset = self.u*rd.x + self.v*rd.y
   ray(

--- a/trace_of_radiance/physics/materials.nim
+++ b/trace_of_radiance/physics/materials.nim
@@ -21,7 +21,7 @@ import
 func lambertian*(albedo: Attenuation): Lambertian {.inline.} =
   result.albedo = albedo
 
-proc scatter(self: Lambertian, r_in: Ray,
+func scatter(self: Lambertian, r_in: Ray,
               rec: HitRecord, rng: var Rng,
               attenuation: var Attenuation, scattered: var Ray): bool =
   let scatter_direction = rec.normal + rng.random(UnitVector)
@@ -36,7 +36,7 @@ func metal*(albedo: Attenuation, fuzz: float64): Metal {.inline.} =
   result.albedo = albedo
   result.fuzz = min(fuzz, 1)
 
-proc scatter(self: Metal, r_in: Ray,
+func scatter(self: Metal, r_in: Ray,
               rec: HitRecord, rng: var Rng,
               attenuation: var Attenuation, scattered: var Ray): bool =
   let reflected = r_in.direction.unit_vector().reflect(rec.normal)
@@ -59,7 +59,7 @@ func schlick(cosine, refraction_index: float64): float64 =
   r0 *= r0
   return r0 + (1-r0)*pow(1-cosine, 5)
 
-proc scatter(self: Dielectric, r_in: Ray,
+func scatter(self: Dielectric, r_in: Ray,
               rec: HitRecord, rng: var Rng,
               attenuation: var Attenuation, scattered: var Ray): bool =
   attenuation = attenuation(1, 1, 1)
@@ -89,7 +89,7 @@ proc scatter(self: Dielectric, r_in: Ray,
 # ------------------------------------------------------------------------------------------
 
 registerRoutine(Material):
-  proc scatter*(self: Material, r_in: Ray, rec: HitRecord,
+  func scatter*(self: Material, r_in: Ray, rec: HitRecord,
                 rng: var Rng,
                 attenuation: var Attenuation, scattered: var Ray): bool
 

--- a/trace_of_radiance/sampling.nim
+++ b/trace_of_radiance/sampling.nim
@@ -6,67 +6,81 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  std/[random, math],
-  ./primitives
+  std/math,
+  ./primitives,
+  ./support/rng
+
+export rng
 
 # Random routines
 # ------------------------------------------------------
 
-var globalRng = initRand(0xFACADE) # TODO: init per thread
+proc random*(rng: var Rng, _: type float64): float64 {.inline.} =
+  rng.uniform(float64)
 
-proc random*(_: type float64): float64 =
-  globalRng.rand(1.0)
+proc random*(rng: var Rng, _: type float64, max: float64): float64 {.inline.} =
+  rng.uniform(max)
 
-proc random*(_: type float64, min, max: float64): float64 =
-  globalRng.rand(min..max)
+proc random*(rng: var Rng, _: type float64, min, max: float64): float64 {.inline.} =
+  rng.uniform(min, max)
 
 # Vector
 # ------------------------------------------------------
 
-proc random(_: type Vec3): Vec3 =
-  result.x = float64.random()
-  result.y = float64.random()
-  result.z = float64.random()
+proc random(rng: var Rng, _: type Vec3): Vec3 {.inline.} =
+  result.x = rng.random(float64)
+  result.y = rng.random(float64)
+  result.z = rng.random(float64)
 
-proc random(_: type Vec3, min, max: float64): Vec3 =
-  result.x = globalRng.rand(min..max)
-  result.y = globalRng.rand(min..max)
-  result.z = globalRng.rand(min..max)
+proc random(rng: var Rng, _: type Vec3, max: float64): Vec3 {.inline.} =
+  result.x = rng.random(float64, max)
+  result.y = rng.random(float64, max)
+  result.z = rng.random(float64, max)
 
-proc random_in_unit_sphere*(_: type Vec3): Vec3 =
+proc random(rng: var Rng,  _: type Vec3, min, max: float64): Vec3 {.inline.} =
+  result.x = rng.random(float64, min, max)
+  result.y = rng.random(float64, min, max)
+  result.z = rng.random(float64, min, max)
+
+proc random_in_unit_sphere*(rng: var Rng, _: type Vec3): Vec3 =
   while true:
-    let p = Vec3.random(-1, 1)
+    let p = rng.random(Vec3, -1, 1)
     if p.length_squared() < 1.0:
       return p
 
-proc random_unit_vector*(): Vec3 =
-  let a = globalRng.rand(0.0 .. 2*PI)
-  let z = globalRng.rand(-1.0 .. 1.0)
+proc random*(rng: var Rng, _: type UnitVector): UnitVector =
+  let a = rng.random(float64, 2*PI)
+  let z = rng.random(float64, -1.0, 1.0)
   let r = sqrt(1.0 - z*z)
-  return vec3(r*cos(a), r*sin(a), z)
+  return toUV(vec3(r*cos(a), r*sin(a), z))
 
-proc random_in_hemisphere*(normal: Vec3): Vec3 =
-  let in_unit_sphere = Vec3.random_in_unit_sphere()
+proc random_in_hemisphere*(rng: var Rng, _: type Vec3, normal: Vec3): Vec3 =
+  let in_unit_sphere = rng.random_in_unit_sphere(Vec3)
   if in_unit_sphere.dot(normal) > 0.0: # In the same hemisphere as normal
     return in_unit_sphere
   else:
     return -in_unit_sphere
 
-proc random_in_unit_disk*(): Vec3 =
+proc random_in_unit_disk*(rng: var Rng, _: type Vec3): Vec3 =
   while true:
-    result = vec3(globalRng.rand(-1.0..1.0), globalRng.rand(-1.0..1.0), 0)
+    result = vec3(rng.random(float64, -1.0, 1.0), rng.random(float64, -1.0, 1.0), 0)
     if result.length_squared() < 1:
       return
 
 # Color
 # ------------------------------------------------------
 
-proc random*(_: type Attenuation): Attenuation =
-  result.x = float64.random()
-  result.y = float64.random()
-  result.z = float64.random()
+proc random*(rng: var Rng, _: type Attenuation): Attenuation {.inline.} =
+  result.x = rng.random(float64)
+  result.y = rng.random(float64)
+  result.z = rng.random(float64)
 
-proc random*(_: type Attenuation, min, max: float64): Attenuation =
-  result.x = globalRng.rand(min..max)
-  result.y = globalRng.rand(min..max)
-  result.z = globalRng.rand(min..max)
+proc random*(rng: var Rng, _: type Attenuation, max: float64): Attenuation {.inline.} =
+  result.x = rng.random(float64, max)
+  result.y = rng.random(float64, max)
+  result.z = rng.random(float64, max)
+
+proc random*(rng: var Rng, _: type Attenuation, min, max: float64): Attenuation {.inline.} =
+  result.x = rng.random(float64, min, max)
+  result.y = rng.random(float64, min, max)
+  result.z = rng.random(float64, min, max)

--- a/trace_of_radiance/sampling.nim
+++ b/trace_of_radiance/sampling.nim
@@ -15,53 +15,53 @@ export rng
 # Random routines
 # ------------------------------------------------------
 
-proc random*(rng: var Rng, _: type float64): float64 {.inline.} =
+func random*(rng: var Rng, _: type float64): float64 {.inline.} =
   rng.uniform(float64)
 
-proc random*(rng: var Rng, _: type float64, max: float64): float64 {.inline.} =
+func random*(rng: var Rng, _: type float64, max: float64): float64 {.inline.} =
   rng.uniform(max)
 
-proc random*(rng: var Rng, _: type float64, min, max: float64): float64 {.inline.} =
+func random*(rng: var Rng, _: type float64, min, max: float64): float64 {.inline.} =
   rng.uniform(min, max)
 
 # Vector
 # ------------------------------------------------------
 
-proc random(rng: var Rng, _: type Vec3): Vec3 {.inline.} =
+func random(rng: var Rng, _: type Vec3): Vec3 {.inline.} =
   result.x = rng.random(float64)
   result.y = rng.random(float64)
   result.z = rng.random(float64)
 
-proc random(rng: var Rng, _: type Vec3, max: float64): Vec3 {.inline.} =
+func random(rng: var Rng, _: type Vec3, max: float64): Vec3 {.inline.} =
   result.x = rng.random(float64, max)
   result.y = rng.random(float64, max)
   result.z = rng.random(float64, max)
 
-proc random(rng: var Rng,  _: type Vec3, min, max: float64): Vec3 {.inline.} =
+func random(rng: var Rng,  _: type Vec3, min, max: float64): Vec3 {.inline.} =
   result.x = rng.random(float64, min, max)
   result.y = rng.random(float64, min, max)
   result.z = rng.random(float64, min, max)
 
-proc random_in_unit_sphere*(rng: var Rng, _: type Vec3): Vec3 =
+func random_in_unit_sphere*(rng: var Rng, _: type Vec3): Vec3 =
   while true:
     let p = rng.random(Vec3, -1, 1)
     if p.length_squared() < 1.0:
       return p
 
-proc random*(rng: var Rng, _: type UnitVector): UnitVector =
+func random*(rng: var Rng, _: type UnitVector): UnitVector =
   let a = rng.random(float64, 2*PI)
   let z = rng.random(float64, -1.0, 1.0)
   let r = sqrt(1.0 - z*z)
   return toUV(vec3(r*cos(a), r*sin(a), z))
 
-proc random_in_hemisphere*(rng: var Rng, _: type Vec3, normal: Vec3): Vec3 =
+func random_in_hemisphere*(rng: var Rng, _: type Vec3, normal: Vec3): Vec3 =
   let in_unit_sphere = rng.random_in_unit_sphere(Vec3)
   if in_unit_sphere.dot(normal) > 0.0: # In the same hemisphere as normal
     return in_unit_sphere
   else:
     return -in_unit_sphere
 
-proc random_in_unit_disk*(rng: var Rng, _: type Vec3): Vec3 =
+func random_in_unit_disk*(rng: var Rng, _: type Vec3): Vec3 =
   while true:
     result = vec3(rng.random(float64, -1.0, 1.0), rng.random(float64, -1.0, 1.0), 0)
     if result.length_squared() < 1:
@@ -70,17 +70,17 @@ proc random_in_unit_disk*(rng: var Rng, _: type Vec3): Vec3 =
 # Color
 # ------------------------------------------------------
 
-proc random*(rng: var Rng, _: type Attenuation): Attenuation {.inline.} =
+func random*(rng: var Rng, _: type Attenuation): Attenuation {.inline.} =
   result.x = rng.random(float64)
   result.y = rng.random(float64)
   result.z = rng.random(float64)
 
-proc random*(rng: var Rng, _: type Attenuation, max: float64): Attenuation {.inline.} =
+func random*(rng: var Rng, _: type Attenuation, max: float64): Attenuation {.inline.} =
   result.x = rng.random(float64, max)
   result.y = rng.random(float64, max)
   result.z = rng.random(float64, max)
 
-proc random*(rng: var Rng, _: type Attenuation, min, max: float64): Attenuation {.inline.} =
+func random*(rng: var Rng, _: type Attenuation, min, max: float64): Attenuation {.inline.} =
   result.x = rng.random(float64, min, max)
   result.y = rng.random(float64, min, max)
   result.z = rng.random(float64, min, max)

--- a/trace_of_radiance/scenes.nim
+++ b/trace_of_radiance/scenes.nim
@@ -10,7 +10,7 @@ import
   ./sampling,
   ./primitives
 
-proc random_scene*(rng: var Rng): HittableList =
+func random_scene*(rng: var Rng): HittableList =
   let ground_material = lambertian attenuation(0.5,0.5,0.5)
   result.add sphere(center = point3(0,-1000,0), 1000, ground_material)
 

--- a/trace_of_radiance/scenes.nim
+++ b/trace_of_radiance/scenes.nim
@@ -10,17 +10,17 @@ import
   ./sampling,
   ./primitives
 
-proc random_scene*(): HittableList =
+proc random_scene*(rng: var Rng): HittableList =
   let ground_material = lambertian attenuation(0.5,0.5,0.5)
   result.add sphere(center = point3(0,-1000,0), 1000, ground_material)
 
   for a in -11 ..< 11:
     for b in -11 ..< 11:
-      let choose_mat = float64.random()
+      let choose_mat = rng.random(float64)
       let center = point3(
-        a.float64 + 0.9*float64.random(),
+        a.float64 + 0.9*rng.random(float64),
         0.2,
-        b.float64 + 0.9*float64.random()
+        b.float64 + 0.9*rng.random(float64)
       )
 
       # In the book it's vec3(4, 0.2, 0) but it doesn't make physical sense
@@ -29,13 +29,13 @@ proc random_scene*(): HittableList =
       if length(center - point3(4, 0.2, 0)) > 0.9:
         if choose_mat < 0.8:
           # Diffuse
-          let albedo = Attenuation.random() * Attenuation.random()
+          let albedo = rng.random(Attenuation) * rng.random(Attenuation)
           let sphere_material = lambertian albedo
           result.add sphere(center, 0.2, sphere_material)
         elif choose_mat < 0.95:
           # Metal
-          let albedo = Attenuation.random(0.5, 1)
-          let fuzz = float64.random(0.0, 0.5)
+          let albedo = rng.random(Attenuation, 0.5, 1)
+          let fuzz = rng.random(float64, max = 0.5)
           let sphere_material = metal(albedo, fuzz)
           result.add sphere(center, 0.2, sphere_material)
         else:

--- a/trace_of_radiance/support/emulate_classes_with_ADTs.nim
+++ b/trace_of_radiance/support/emulate_classes_with_ADTs.nim
@@ -77,7 +77,7 @@ macro registerRoutine*(className, routine: untyped) =
   ##     scatter(self: Material, r_in: Ray, rec: HitRecord): Option[color: attenuation, scattered: Ray]
   ClassRegistry[className].routines.add routine
 
-proc exported(name: string): NimNode =
+func exported(name: string): NimNode =
   nnkPostfix.newTree(
     newIdentNode"*",
     newIdentNode name
@@ -152,8 +152,8 @@ macro generateClass*(className, constructorName: untyped) =
   # Debug display
   # echo result.toStrLit()
 
-proc replaceNode(ast, toReplace, replaceBy: NimNode): NimNode =
-  proc inspect(node: NimNode): NimNode =
+func replaceNode(ast, toReplace, replaceBy: NimNode): NimNode =
+  func inspect(node: NimNode): NimNode =
     case node.kind:
     of {nnkIdent, nnkSym}:
       if node.eqIdent(toReplace):

--- a/trace_of_radiance/support/rng.nim
+++ b/trace_of_radiance/support/rng.nim
@@ -126,13 +126,7 @@ func uniform*(rng: var Rng, minIncl, maxExcl: float64): float64 =
     debiaised * (maxExcl - minIncl) + minIncl
   )
 
-func uniform*(rng*: var float64, _: type float64): float64 =
-  let mantissa = rng.next() shr (F64_Bits - F64_MantissaBits)
-  let fl = mantissa or cast[uint64](1'f64)
-  # Debiaised by removing 1
-  return cast[float64](fl) - 1'f64
-
-func uniform*(rng*: var float64, _: type float64): float64 =
+func uniform*(rng: var Rng, _: type float64): float64 =
   let mantissa = rng.next() shr (F64_Bits - F64_MantissaBits)
   let fl = mantissa or cast[uint64](1'f64)
   # Debiaised by removing 1

--- a/trace_of_radiance/support/rng.nim
+++ b/trace_of_radiance/support/rng.nim
@@ -1,0 +1,210 @@
+# Trace of Radiance
+# Copyright (c) 2020 Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# Random Number Generator
+# ----------------------------------------------------------------------------------
+
+# We use the high bits of xoshiro256+
+# as we are focused on floating points.
+#
+# http://prng.di.unimi.it/
+#
+# We initialize the RNG with SplitMix64
+
+type Rng* = object
+  s0, s1, s2, s3: uint64
+
+func pair(x, y: SomeInteger): uint64 {.inline.} =
+  ## A simple way to produce a unique uint64
+  ## from 2 integers
+  ## Simpler and faster than
+  ## - Cantor pairing: https://en.wikipedia.org/wiki/Pairing_function#Cantor_pairing_function
+  ## - Szudzik pairing: http://szudzik.com/ElegantPairing.pdf
+  ## for integers bounded to uint32.
+  ## Beyond there is collision
+  (x.uint64 shl 32) xor y.uint64
+
+func splitMix64(state: var uint64): uint64 =
+  state += 0x9e3779b97f4a7c15'u64
+  result = state
+  result = (result xor (result shr 30)) * 0xbf58476d1ce4e5b9'u64
+  result = (result xor (result shr 27)) * 0xbf58476d1ce4e5b9'u64
+  result = result xor (result shr 31)
+
+func seed*(rng: var Rng, x: SomeInteger) =
+  ## Seed the random number generator with a fixed seed
+  var sm64 = uint64(x)
+  rng.s0 = splitMix64(sm64)
+  rng.s1 = splitMix64(sm64)
+  rng.s2 = splitMix64(sm64)
+  rng.s3 = splitMix64(sm64)
+
+func seed*(rng: var Rng, x, y: SomeInteger) =
+  ## Seed the random number generator from 2 integers
+  ## for example, the iteration variable
+  var sm64 = pair(x, y)
+  rng.s0 = splitMix64(sm64)
+  rng.s1 = splitMix64(sm64)
+  rng.s2 = splitMix64(sm64)
+  rng.s3 = splitMix64(sm64)
+
+func rotl(x: uint64, k: static int): uint64 {.inline.} =
+  return (x shl k) or (x shr (64 - k))
+
+func next(rng: var Rng): uint64 =
+  ## Compute a random uint64 from the input state
+  ## using xoshiro256+ algorithm by Vigna et al
+  ## State is updated.
+  ## The lowest 3-bit have low linear complexity
+  ## For floating point use the 53 high bits
+  result = rng.s0 + rng.s3
+  let t = rng.s1 shl 17
+
+  rng.s2 = rng.s2 xor rng.s0
+  rng.s3 = rng.s3 xor rng.s1
+  rng.s1 = rng.s1 xor rng.s2
+  rng.s0 = rng.s0 xor rng.s3
+
+  rng.s2 = rng.s2 xor t
+
+  rng.s3 = rotl(rng.s3, 45)
+
+func uniform*(rng: var Rng, maxExcl: uint32): uint32 =
+  ## Generate a random integer in 0 ..< maxExclusive
+  ## Uses an unbiaised generation method
+  ## See Lemire's algorithm modified by Melissa O'Neill
+  ##   https://www.pcg-random.org/posts/bounded-rands.html
+  ## - Unbiaised
+  ## - Features only a single modulo operation
+  assert maxExcl > 0
+  let max = maxExcl
+  var x = uint32 (rng.next() shr 32) # The higher 32-bit are of higher quality with xoshiro256+
+  var m = x.uint64 * max.uint64
+  var l = uint32 m
+  if l < max:
+    var t = not(max) + 1 # -max
+    if t >= max:
+      t -= max
+      if t >= max:
+        t = t mod max
+    while l < t:
+      x = uint32 rng.next()
+      m = x.uint64 * max.uint64
+      l = uint32 m
+  return uint32(m shr 32)
+
+func uniform*[T: SomeInteger](rng: var Rng, minIncl, maxExcl: T): T =
+  ## Return a random integer in the given range.
+  ## The range bounds must fit in an int32.
+  let maxExclusive = maxExcl - minIncl
+  result = T(rng.uniform(uint32 maxExclusive))
+  result += minIncl
+
+# TODO, not enough research in float64 PRNG
+# - Generating Random Floating-Point Numbers by Dividing Integers: a Case Study
+#   Frédéric Goualard, 2020
+#   http://frederic.goualard.net/publications/fpnglib1.pdf
+
+const
+  F64_Bits = 64
+  F64_MantissaBits = 52
+
+func uniform*(rng: var Rng, minIncl, maxExcl: float64): float64 =
+  # Create a random mantissa with exponent of 1
+  let mantissa = rng.next() shr (F64_Bits - F64_MantissaBits)
+  let fl = mantissa or cast[uint64](1'f64)
+  # Debiaised by removing 1
+  let debiaised = cast[float64](fl) - 1'f64
+
+  # Scale to the target range
+  return max(
+    minIncl,
+    debiaised * (maxExcl - minIncl) + minIncl
+  )
+
+func uniform*(rng*: var float64, _: type float64): float64 =
+  let mantissa = rng.next() shr (F64_Bits - F64_MantissaBits)
+  let fl = mantissa or cast[uint64](1'f64)
+  # Debiaised by removing 1
+  return cast[float64](fl) - 1'f64
+
+func uniform*(rng*: var float64, _: type float64): float64 =
+  let mantissa = rng.next() shr (F64_Bits - F64_MantissaBits)
+  let fl = mantissa or cast[uint64](1'f64)
+  # Debiaised by removing 1
+  return cast[float64](fl) - 1'f64
+
+func uniform*(rng: var Rng, maxExcl: float64): float64 =
+  # Create a random mantissa with exponent of 1
+  let mantissa = rng.next() shr (F64_Bits - F64_MantissaBits)
+  let fl = mantissa or cast[uint64](1'f64)
+  # Debiaised by removing 1
+  let debiaised = cast[float64](fl) - 1'f64
+
+  # Scale to the target range
+  return debiaised * maxExcl
+
+# Sanity checks
+# ------------------------------------------------------------
+
+when isMainModule:
+  import std/[tables, times]
+  # TODO: proper statistical tests
+
+  proc uniform_uint() =
+    var rng: Rng
+    let timeSeed = uint32(getTime().toUnix() and (1'i64 shl 32 - 1)) # unixTime mod 2^32
+    rng.seed(timeSeed)
+    echo "prng_sanity_checks - uint32 - xoshiro256+ seed: ", timeSeed
+
+    proc test[T](min, maxExcl: T) =
+      var c = initCountTable[int]()
+
+      for _ in 0 ..< 1_000_000:
+        c.inc(rng.uniform(min, maxExcl))
+
+      echo "1'000'000 pseudo-random outputs from ", min, " to ", maxExcl, " (excl): ", c
+
+    test(0, 2)
+    test(0, 3)
+    test(1, 53)
+    test(-10, 11)
+
+  uniform_uint()
+  echo "\n--------------------------------------------------------\n"
+
+  proc uniform_f64() =
+    var rng: Rng
+    let timeSeed = uint32(getTime().toUnix() and (1'i64 shl 32 - 1)) # unixTime mod 2^32
+    rng.seed(timeSeed)
+    echo "prng_sanity_checks - float64 - xoshiro256+ seed: ", timeSeed
+
+    proc bin(f, bucketsWidth, min: float64): int =
+      # Idea: we split the range into buckets
+      # and we verify that the size of the buckets is similar
+      int((f - min) / bucketsWidth)
+
+    proc test[T](min, maxExcl: T, buckets: int) =
+
+      var c = initCountTable[int]()
+
+      let bucketsWidth = (maxExcl - min) / float64(buckets)
+
+      for _ in 0 ..< 1_000_000:
+        c.inc(rng.uniform(min, maxExcl).bin(bucketsWidth, min))
+
+      echo "1'000'000 pseudo-random outputs from ", min, " to ", maxExcl, " (excl): ", c
+
+    test(0.0, 2.0, 10)
+    test(0.0, 2.0, 20)
+    test(0.0, 3.0, 10)
+    test(0.0, 1.0, 10)
+    test(0.0, 1.0, 20)
+    test(-1.0, 1.0, 10)
+    test(-1.0, 1.0, 20)
+
+  uniform_f64()


### PR DESCRIPTION
This refactor the sampling to use a custom RNG

## Features

- Most routines are now stateless and don't access a global state, making them suitable for parallelization
- The RNG is can be seeded from a pair of numbers like the loop iteration variable, solving the issue of reproducibility when dynamic loop splitting is done by the multithreading runtime (https://github.com/mratsim/weave/issues/147)
- The seeding is of much higher quality than Nim's default https://github.com/nim-lang/Nim/blob/c61f7466292cb19c910f4a2f2976f738796e6bdf/lib/pure/random.nim#L551-L575 which tends to lead to huge chunk of zero in the PRNG state
- Fast unbiaised uniform integer production (only a single modulo instead of 2 for rejection sampling.

## Impact

A loss of 3% perf (40s instead of 38s) which is acceptable as a prerequisite for parallel RNG (see https://github.com/mratsim/weave/issues/147 for comparison with Pedigree-based RNGs and Splittable RNGs)

Furthermore, Nim uses xoroshiro128+ while I use xoshiro256+

![image](https://user-images.githubusercontent.com/22738317/82734406-14640b00-9d1b-11ea-8ebd-0c1f7cb519ee.png)

xoroshiro18+ is about 7.5% faster. Furthermore there is an extra parameter to pass and the PRNG is reseeded at each loop iteration via splitmix64

![image](https://user-images.githubusercontent.com/22738317/82734364-de268b80-9d1a-11ea-906f-673b43eef394.png)

## Image

Different RNG -> Different images generated:

Before:
![image](https://raw.githubusercontent.com/mratsim/trace-of-radiance/master/media/in_one_weekend.png)
After
![image](https://user-images.githubusercontent.com/22738317/82734808-99e8ba80-9d1d-11ea-9751-f93c49c0f9d6.png)
