### PR TITLE
Parallelism

### DIFF
--- a/trace_of_radiance.nim
+++ b/trace_of_radiance.nim
@@ -48,10 +48,12 @@ proc main() =
                  samples_per_pixel,
                  gamma_correction
                )
+  defer: canvas.delete()
 
   canvas.render(cam, world.list(), max_depth)
 
   stdout.exportToPPM canvas
   stderr.write "\nDone.\n"
+
 
 main()

--- a/trace_of_radiance.nim
+++ b/trace_of_radiance.nim
@@ -14,7 +14,8 @@ import
     physics/cameras,
     render,
     scenes,
-    sampling
+    sampling,
+    io/ppm
   ]
 
 proc main() =
@@ -22,9 +23,8 @@ proc main() =
   const image_width = 384
   const image_height = int(image_width / aspect_ratio)
   const samples_per_pixel = 100
+  const gamma_correction = 2.2
   const max_depth = 50
-
-  stdout.write &"P3\n{image_width} {image_height}\n255\n"
 
   var worldRNG: Rng
   worldRNG.seed 0xFACADE
@@ -44,12 +44,15 @@ proc main() =
               aspect_ratio, aperture, dist_to_focus
             )
 
-  stdout.renderToPPM(
-    cam, world,
-    image_height, image_width,
-    samples_per_pixel, max_depth
-  )
+  var canvas = newCanvas(
+                 image_height, image_width,
+                 samples_per_pixel,
+                 gamma_correction
+               )
 
+  canvas.render(cam, world, max_depth)
+
+  stdout.exportToPPM canvas
   stderr.write "\nDone.\n"
 
 main()

--- a/trace_of_radiance.nim
+++ b/trace_of_radiance.nim
@@ -6,8 +6,6 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  # Stdlib
-  std/strformat,
   # Internals
   ./trace_of_radiance/[
     primitives,

--- a/trace_of_radiance.nim
+++ b/trace_of_radiance.nim
@@ -12,6 +12,7 @@ import
   ./trace_of_radiance/[
     primitives,
     physics/cameras,
+    physics/hittables,
     render,
     scenes,
     sampling,
@@ -50,7 +51,7 @@ proc main() =
                  gamma_correction
                )
 
-  canvas.render(cam, world, max_depth)
+  canvas.render(cam, world.list(), max_depth)
 
   stdout.exportToPPM canvas
   stderr.write "\nDone.\n"

--- a/trace_of_radiance/io/ppm.nim
+++ b/trace_of_radiance/io/ppm.nim
@@ -11,20 +11,17 @@ import
   # internal
   ../primitives
 
-proc write*(f: File, pixelColor: Color, samples_per_pixel: int) =
-  var r = pixelColor.x
-  var g = pixelColor.y
-  var b = pixelColor.z
-
-  # Divide the color total by the number of samples
-  # We also do gamma correction for gamma = 2, i.e. pixel^(1/2)
-  let scale = 1.0 / float64(samples_per_pixel)
-  r = sqrt(scale * r)
-  g = sqrt(scale * g)
-  b = sqrt(scale * b)
-
+proc exportToPPM*(f: File, canvas: Canvas) =
   template conv(c: float64): int =
     int(256 * clamp(c, 0.0, 0.999))
 
-  # Write the translated [0, 255] value of each color component
-  f.write &"{conv(r)} {conv(g)} {conv(b)}\n"
+  stdout.write &"P3\n{canvas.ncols} {canvas.nrows}\n255\n"
+
+  for i in countdown(canvas.nrows-1,0):
+    for j in 0 ..< canvas.ncols:
+      # Write the translated [0, 255] value of each color component
+      let pixel = canvas[i, j]
+      let r = pixel.x
+      let g = pixel.y
+      let b = pixel.z
+      f.write &"{conv(r)} {conv(g)} {conv(b)}\n"

--- a/trace_of_radiance/primitives.nim
+++ b/trace_of_radiance/primitives.nim
@@ -7,9 +7,11 @@
 
 import primitives/[
   safe_math, rays,
-  vec3s, point3s, colors
+  vec3s, point3s, colors,
+  canvas
 ]
 
 export
   safe_math, rays,
-  vec3s, point3s, colors
+  vec3s, point3s, colors,
+  canvas

--- a/trace_of_radiance/primitives/canvas.nim
+++ b/trace_of_radiance/primitives/canvas.nim
@@ -1,0 +1,57 @@
+# Trace of Radiance
+# Copyright (c) 2020 Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Low-level
+  system/ansi_c,
+  # Stdlib
+  std/math,
+  # Internal
+  ./colors
+
+# Canvas
+# ------------------------------------------------------------------------
+# A Canvas is a 2D Buffer
+
+type
+  Canvas* = object
+    ## 2D Buffer
+    ## Images are stored in row-major order
+    # Size 24 bytes
+    pixels*: ptr UncheckedArray[Color]
+    nrows*, ncols*: int32
+    samples_per_pixel*: int32
+    gamma_correction*: float32
+
+
+proc newCanvas*(
+       height, width,
+       samples_per_pixel: SomeInteger,
+       gamma_correction: SomeFloat): Canvas =
+  result.nrows = int32 height
+  result.ncols = int32 width
+  result.samples_per_pixel = int32 samples_per_pixel
+  result.pixels = cast[ptr UncheckedArray[Color]](
+    c_malloc(csize_t height * width * sizeof(Color))
+  )
+  result.gamma_correction = float32(gamma_correction)
+
+proc delete*(canvas: var Canvas) {.inline.} =
+  if not canvas.pixels.isNil:
+    c_free(canvas.pixels)
+
+func draw*(canvas: var Canvas, row, col: int32, pixel: Color) {.inline.} =
+  # Draw a gamma-corrected pixel in the canvas
+  let scale = 1.0 / canvas.samples_per_pixel.float64
+  let gamma = 1.0 / canvas.gamma_correction.float64
+  let pos = row*canvas.ncols + col
+  canvas.pixels[pos].x = pow(scale * pixel.x, gamma)
+  canvas.pixels[pos].y = pow(scale * pixel.y, gamma)
+  canvas.pixels[pos].z = pow(scale * pixel.z, gamma)
+
+proc `[]`*(canvas: Canvas, row, col: int32): Color {.inline.} =
+  canvas.pixels[row*canvas.ncols + col]

--- a/trace_of_radiance/primitives/canvas.nim
+++ b/trace_of_radiance/primitives/canvas.nim
@@ -44,7 +44,7 @@ proc delete*(canvas: var Canvas) {.inline.} =
   if not canvas.pixels.isNil:
     c_free(canvas.pixels)
 
-func draw*(canvas: var Canvas, row, col: int32, pixel: Color) {.inline.} =
+func draw*(canvas: var Canvas, row, col: SomeInteger, pixel: Color) {.inline.} =
   # Draw a gamma-corrected pixel in the canvas
   let scale = 1.0 / canvas.samples_per_pixel.float64
   let gamma = 1.0 / canvas.gamma_correction.float64
@@ -53,5 +53,5 @@ func draw*(canvas: var Canvas, row, col: int32, pixel: Color) {.inline.} =
   canvas.pixels[pos].y = pow(scale * pixel.y, gamma)
   canvas.pixels[pos].z = pow(scale * pixel.z, gamma)
 
-proc `[]`*(canvas: Canvas, row, col: int32): Color {.inline.} =
+proc `[]`*(canvas: Canvas, row, col: SomeInteger): Color {.inline.} =
   canvas.pixels[row*canvas.ncols + col]

--- a/trace_of_radiance/render.nim
+++ b/trace_of_radiance/render.nim
@@ -6,7 +6,9 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
+  # Standard library
   std/strformat,
+  # Internal
   ./primitives,
   ./sampling,
   ./io/ppm,
@@ -45,8 +47,6 @@ func radiance*(ray: Ray, world: Hittable, max_depth: int, rng: var Rng): Color =
 
 proc render*(canvas: var Canvas, cam: Camera, world: HittableList, max_depth: int) =
   for row in 0'i32 ..< canvas.nrows:
-    stderr.write &"\rScanlines remaining: {canvas.nrows - row}"
-    stderr.flushFile()
     for col in 0'i32 ..< canvas.ncols:
       var rng: Rng   # We reseed per pixel to be able to parallelize the outer loops
       rng.seed(row, col) # And use a "perfect hash" as the seed

--- a/trace_of_radiance/scenes.nim
+++ b/trace_of_radiance/scenes.nim
@@ -10,7 +10,7 @@ import
   ./sampling,
   ./primitives
 
-func random_scene*(rng: var Rng): HittableList =
+func random_scene*(rng: var Rng): Scene =
   let ground_material = lambertian attenuation(0.5,0.5,0.5)
   result.add sphere(center = point3(0,-1000,0), 1000, ground_material)
 

--- a/trace_of_radiance/trace_of_radiance.nimble
+++ b/trace_of_radiance/trace_of_radiance.nimble
@@ -1,0 +1,9 @@
+# Package
+
+version       = "0.1.9"
+author        = "Mamy André-Ratsimbazafy"
+description   = "An educational raytracer"
+license       = "MIT or Apache License 2.0"
+
+# Dependencies
+requires "nim >= 1.2.0", "weave"


### PR DESCRIPTION
This allows parallelized rendering via Weave.

Summary:
- No openarray as value, so I had to make my own ptr + len HittableList to make it threadsafe.
  No lifetime tracking though :/ https://github.com/nim-lang/RFCs/issues/178
- Rendering is done to an intermediate Canvas buffer instead of directly to disk
- Applying samples scaling and gamma correction has been moved into the rendering loop to benefit from parallelism
- Gamma correction is now the classic 2.2 instead of 2


Performance:
- 2.376s instead of 39.9s for a 16.8x speedup on 18 cores machine
Strangely this does not scale as well as SmallPT (over 20x) https://github.com/mratsim/weave/tree/9f0c384fe905f36ccdcd87ffab28639ba94d395c/demos/raytracing